### PR TITLE
Refactor app.js to Remove Duplicate Session Middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,8 +7,8 @@ const cookieParser = require("cookie-parser");
 const session = require("express-session");
 const MongoStore = require("connect-mongo");
 const rfs = require("rotating-file-stream");
-const passport = require('passport'); // Added passport for authentication
-const flash = require('connect-flash'); // Added flash for storing flash messages
+const passport = require("passport"); // Added passport for authentication
+const flash = require("connect-flash"); // Added flash for storing flash messages
 
 const connectDB = require("./server/config/db");
 const { isActiveRoute } = require("./server/helpers/routeHelpers");
@@ -28,17 +28,6 @@ const accessLogStream = rfs.createStream("application.log", {
 app.use(morgan("combined", { stream: accessLogStream }));
 
 // Connect to DB
-
-app.use(session({
-    secret: 'your_secret_key', // Change this to your secret key
-    resave: false,
-    saveUninitialized: true,
-}));
-
-app.use(flash());
-
-
-// Connect to MongoDB
 connectDB();
 
 // Middleware setup
@@ -57,7 +46,7 @@ app.use(
     store: MongoStore.create({
       mongoUrl: process.env.MONGODB_URI, // Use MongoDB Atlas URI from .env
     }),
-    // cookie: { maxAge: new Date(Date.now() + 3600000) }// Uncomment if you want custom cookie expiry time
+    // cookie: { maxAge: new Date(Date.now() + 3600000) } // Uncomment if you want custom cookie expiry time
   })
 );
 
@@ -65,6 +54,8 @@ app.use(
 app.use(passport.initialize());
 app.use(passport.session()); // Persist user sessions
 
+// Flash message setup
+app.use(flash());
 
 // Global variables for flash messages
 app.use((req, res, next) => {


### PR DESCRIPTION
This pull request addresses an issue where two instances of the session() middleware were present in app.js, potentially causing conflicts with session management. The second session() middleware already handles the session storage and configuration, including MongoDB integration, making the first one redundant.

Changes Made:
- Removed the redundant session() middleware setup at the beginning of the app.js file.
- Ensured that the second instance of the session() middleware, which integrates with MongoDB session storage, remains intact.
- Verified that Passport.js session persistence is correctly set up.

### Fixes issue #72 

Impact:
- This change ensures cleaner code and avoids any possible session conflicts.
- The app should now properly handle user sessions with the MongoDB store and Passport.js.